### PR TITLE
Fix use of to_parquet in storage tutorial

### DIFF
--- a/07_dataframe_storage.ipynb
+++ b/07_dataframe_storage.ipynb
@@ -267,7 +267,7 @@
    "outputs": [],
    "source": [
     "target = os.path.join('data', 'accounts.parquet')\n",
-    "df_csv.categorize(columns=['names']).to_parquet(target, has_nulls=False)"
+    "df_csv.categorize(columns=['names']).to_parquet(target, storage_options={"has_nulls": True}, engine="fastparquet")"
    ]
   },
   {


### PR DESCRIPTION
- 'has_nulls=True' was replaced with 'storage_options={"has_nulls": True}'
- engine was changed to "fastparquet"
  - avoids error: "TypeError: unhashable type: 'dict'"

Fix  #124