### PR TITLE
Fix Binder comment action repo and ref

### DIFF
--- a/.github/workflows/ci-binder-link-comment.yaml
+++ b/.github/workflows/ci-binder-link-comment.yaml
@@ -1,4 +1,4 @@
-name: Comment with Binder link on PRs
+name: Comment with Binder link
 
 on: pull_request_target
 

--- a/.github/workflows/ci-binder-link-comment.yaml
+++ b/.github/workflows/ci-binder-link-comment.yaml
@@ -13,7 +13,6 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Beep boop! Here is a Binder link where you can try out this change.
-            [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${{github.repository}}/${{github.ref}})
+            Beep boop! Here is a Binder link where you can try out this change. [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${{ (github.event.pull_request_target || github.event.pull_request).head.repo.full_name }}/${{ (github.event.pull_request_target || github.event.pull_request).head.sha }})
           comment_includes: "Binder link"
           GITHUB_TOKEN: ${{ secrets.DASK_BOT_TOKEN }}


### PR DESCRIPTION
It almost worked! Had to use `pull_request_target` to safely run the action which broke the Binder link. This should fix it 🤞🏻